### PR TITLE
Crashpad for Database Errors

### DIFF
--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/data/DatabaseImpl.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/data/DatabaseImpl.kt
@@ -1,25 +1,16 @@
 package com.afkanerd.smswithoutborders_libsmsmms.data
 
 import android.content.Context
-import android.widget.Toast
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
-import com.afkanerd.lib_smsmms_android.R
 import com.afkanerd.smswithoutborders_libsmsmms.data.Cryptography.getDatabasePassword
 import com.afkanerd.smswithoutborders_libsmsmms.data.dao.ConversationsDao
 import com.afkanerd.smswithoutborders_libsmsmms.data.dao.ThreadsDao
 import com.afkanerd.smswithoutborders_libsmsmms.data.entities.Conversations
 import com.afkanerd.smswithoutborders_libsmsmms.data.entities.Threads
-import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.getNativesLoaded
-import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.setNativesLoaded
-import com.afkanerd.smswithoutborders_libsmsmms.ui.viewModels.ThreadsViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import com.afkanerd.smswithoutborders_libsmsmms.extensions.context.eraseSettings
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import kotlin.concurrent.Volatile
 import kotlin.jvm.java
@@ -32,7 +23,7 @@ import kotlin.jvm.java
     version = 3,
     exportSchema = true,
     autoMigrations = [
-        AutoMigration(from=2, to=3)
+        AutoMigration(from = 2, to = 3)
     ]
 )
 abstract class DatabaseImpl : RoomDatabase() {
@@ -76,6 +67,33 @@ abstract class DatabaseImpl : RoomDatabase() {
                         .fallbackToDestructiveMigration(false)
                         .build()
                 }
+            }
+        }
+
+        /**
+         * This method erases the database, along with other associated settings.
+         */
+        fun erase(context: Context) {
+            context.eraseSettings()
+            java.io.File(databaseName).delete()
+        }
+
+        /**
+         * This method checks if the database is okay, and readable.
+         * Usually, this method is called during the launch of the app,
+         * such that if the method returns false, the user would be prompted to erase everything
+         * and start all over.
+         */
+        fun isOkay(context: Context): Boolean {
+            try {
+                getDatabaseImpl(context)
+                return true
+            } catch (e: Exception) {
+                android.util.Log.d(
+                    "DatabaseImpl",
+                    "The database is not okay because\n${e}\n${e.stackTrace}"
+                )
+                return false
             }
         }
     }

--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Security.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Security.kt
@@ -9,13 +9,12 @@ import java.security.KeyStore
 import java.security.SecureRandom
 
 
-
 private object Security {
     const val FILENAME: String = "com.afkanerd.deku.security"
     const val DB_PASSWORD = "DB_PASSWORD"
 }
 
-fun Context.isAvailableInKeystore(keystoreAlias: String) : Boolean {
+fun Context.isAvailableInKeystore(keystoreAlias: String): Boolean {
     val ks = KeyStore.getInstance("AndroidKeyStore")
     ks.load(null)
     return ks.containsAlias(keystoreAlias)
@@ -33,8 +32,9 @@ fun Context.settingsGetDbPassword(keystoreAlias: String): ByteArray? {
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     ).getString(
-        "Security.DB_PASSWORD_${keystoreAlias}", "").run {
-        if(!this.isNullOrBlank()) Base64.decode(this, Base64.DEFAULT) else null
+        "Security.DB_PASSWORD_${keystoreAlias}", ""
+    ).run {
+        if (!this.isNullOrBlank()) Base64.decode(this, Base64.DEFAULT) else null
     }
 }
 
@@ -50,17 +50,19 @@ fun Context.settingsSetDbPassword(password: ByteArray, keystoreAlias: String) {
         EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
         EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
     ).edit {
-        putString("Security.DB_PASSWORD_${keystoreAlias}",
-            Base64.encodeToString(password, Base64.DEFAULT))
+        putString(
+            "Security.DB_PASSWORD_${keystoreAlias}",
+            Base64.encodeToString(password, Base64.DEFAULT)
+        )
         apply()
     }
 }
 
-fun Context.eraseSettings(){
+fun Context.eraseSettings() {
     this.deleteSharedPreferences(Security.FILENAME)
 }
 
-fun Context.generateSecureRandom() : ByteArray{
+fun Context.generateSecureRandom(): ByteArray {
     val secureRandom = SecureRandom()
     val secretBytes = ByteArray(32) // Example: 256 bits
     secureRandom.nextBytes(secretBytes)

--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Security.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Security.kt
@@ -56,6 +56,10 @@ fun Context.settingsSetDbPassword(password: ByteArray, keystoreAlias: String) {
     }
 }
 
+fun Context.eraseSettings(){
+    this.deleteSharedPreferences(Security.FILENAME)
+}
+
 fun Context.generateSecureRandom() : ByteArray{
     val secureRandom = SecureRandom()
     val secretBytes = ByteArray(32) // Example: 256 bits

--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/ui/DataErasePrompt.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/ui/DataErasePrompt.kt
@@ -1,0 +1,175 @@
+package com.afkanerd.smswithoutborders_libsmsmms.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.*
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import com.afkanerd.smswithoutborders_libsmsmms.data.DatabaseImpl
+import com.afkanerd.smswithoutborders_libsmsmms.ui.viewModels.ThreadsViewModel
+
+/**
+ * This view shows the user a prompt, asking him to erase all app data.
+ * This is usually the effect of corrupted data, especially coming from accidental backups.
+ */
+@Composable
+fun DataErasePrompt(
+    threads: ThreadsViewModel,
+    context: android.content.Context,
+    onEraseComplete: () -> Unit
+) {
+    val consentActive = remember { mutableStateOf(false) }
+
+    MainPrompt(isBlur = consentActive.value, onAction = { consentActive.value = true })
+
+    if (consentActive.value) ConsentPopup(
+        onHide = { consentActive.value = false },
+        onAgree = {
+            android.util.Log.d("DataErasePrompt", "The user agreeeeed!")
+            onEraseComplete()
+            DatabaseImpl.erase(context);
+            onEraseComplete()
+        }
+    )
+
+
+}
+
+
+/**
+ * This subsection of the view is the main area, where the user is explained the situation,
+ * and given the action button to erase data.
+ */
+@Composable
+private fun MainPrompt(isBlur: Boolean, onAction: () -> Unit) {
+    Column(
+        modifier = (if (isBlur) Modifier
+            .blur(6.dp)
+            .alpha(0.4f) else Modifier).fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+
+        Column(
+            modifier = Modifier.widthIn(max = 360.dp)
+        ) {
+            Row(verticalAlignment = Alignment.Top) {
+                Icon(
+                    Icons.Rounded.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.size(50.dp),
+                    tint = MaterialTheme.colorScheme.onBackground
+                )
+
+                Box(modifier = Modifier.width(18.dp))
+
+                Column {
+                    Text(
+                        text = "Data is corrupt",
+                        fontSize = 32.sp,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                    Text(
+                        "The app's data is corrupt. Don't worry, any message stored within your system's storage is not harmed. This only concerns app-specific data. If you had previously disabled writing to system message storage, then your messages following that decision would be lost.",
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            }
+            Box(modifier = Modifier.height(20.dp))
+            CustomButton(onAction = onAction)
+            {
+                Text("Erase & restart", fontSize = 18.sp)
+            }
+
+        }
+    }
+}
+
+/**
+ * This view serves to ask the user to really consent to loosing all his app data.
+ * "Do you really want to do this, dear user?"
+ */
+@Composable
+private fun ConsentPopup(onHide: () -> Unit, onAgree: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Popup(
+            onDismissRequest = onHide,
+            alignment = Alignment.Center,
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 300.dp)
+                    .background(color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f))
+                    .border(
+                        width = 2.dp,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.3f),
+                        shape = RoundedCornerShape(corner = CornerSize(10.dp))
+                    )
+                    .padding(20.dp)
+            ) {
+                Text(
+                    text = "Confirm Action",
+                    fontSize = 32.sp,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+                Text(
+                    "This action would absolutely wipe all app data in a manner that's irreversible. Do you want to continue?",
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+                Box(modifier = Modifier.height(35.dp))
+                CustomButton(
+                    onAction = onAgree,
+                    content = {
+                        Text("Yes, Erase", fontSize = 18.sp)
+                    }
+                )
+            }
+
+        }
+    }
+}
+
+/**
+ * This widget renders a custom button adapted for the style of this view
+ */
+@Composable
+private fun CustomButton(onAction: () -> Unit, content: @Composable () -> Unit) {
+    Button(
+        onClick = onAction,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = MaterialTheme.colorScheme.primary,
+        ), modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 6.dp,
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(
+                    topEnd = 16.dp, bottomEnd = 16.dp, bottomStart = 16.dp, topStart = 16.dp
+                )
+            )
+            .padding(start = 4.dp, end = 4.dp), content = {
+            content()
+        }
+    )
+}

--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/ui/components/NavHostController.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/ui/components/NavHostController.kt
@@ -25,10 +25,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import androidx.window.layout.WindowLayoutInfo
 import com.afkanerd.lib_smsmms_android.R
+import com.afkanerd.smswithoutborders_libsmsmms.data.DatabaseImpl
 import com.afkanerd.smswithoutborders_libsmsmms.data.entities.Conversations
 import com.afkanerd.smswithoutborders_libsmsmms.ui.ComposeNewMessage
 import com.afkanerd.smswithoutborders_libsmsmms.ui.ContactDetails
 import com.afkanerd.smswithoutborders_libsmsmms.ui.ConversationsMainLayout
+import com.afkanerd.smswithoutborders_libsmsmms.ui.DataErasePrompt
 import com.afkanerd.smswithoutborders_libsmsmms.ui.DeveloperModeMain
 import com.afkanerd.smswithoutborders_libsmsmms.ui.MediaMain
 import com.afkanerd.smswithoutborders_libsmsmms.ui.SearchThreadsMain
@@ -75,6 +77,9 @@ fun NavHostControllerInstance(
 //    }
 
     val context = LocalContext.current
+
+    val isDataCorrupt = remember { mutableStateOf(!DatabaseImpl.isOkay(context)) }
+
     threadsViewModel.execMigrations(context)
 
     NavHost(
@@ -84,17 +89,28 @@ fun NavHostControllerInstance(
     ) {
         builder()
 
-        composable<HomeScreenNav>{ backStackEntry ->
-            ThreadConversationLayout(
-                threadsViewModel = threadsViewModel,
-                navController = navController,
-                threadsMainMenuItems = threadsMainMenuItems,
-                modalNavigationModalItems = modalNavigationModalItems,
-                customBottomBar = customBottomBar,
-                customThreadsView = customThreadsView,
-                showTopBar = showThreadsTopBar,
-                appName = appName,
-            )
+        composable<HomeScreenNav> { backStackEntry ->
+            if (isDataCorrupt.value) {
+                DataErasePrompt(
+                    context = context,
+                    threads = threadsViewModel,
+                    onEraseComplete = {
+                        isDataCorrupt.value = false
+                    }
+                )
+            } else {
+                ThreadConversationLayout(
+                    threadsViewModel = threadsViewModel,
+                    navController = navController,
+                    threadsMainMenuItems = threadsMainMenuItems,
+                    modalNavigationModalItems = modalNavigationModalItems,
+                    customBottomBar = customBottomBar,
+                    customThreadsView = customThreadsView,
+                    showTopBar = showThreadsTopBar,
+                    appName = appName,
+                )
+            }
+
         }
         composable<ConversationsScreenNav> { backStackEntry ->
             val convScreen: ConversationsScreenNav = backStackEntry.toRoute()
@@ -119,7 +135,7 @@ fun NavHostControllerInstance(
                 navController = navController
             )
         }
-        composable<ContactDetailsScreenNav>{ backStackEntry ->
+        composable<ContactDetailsScreenNav> { backStackEntry ->
             val contactsDetailsScreen: ContactDetailsScreenNav = backStackEntry.toRoute()
             ContactDetails(
                 address = contactsDetailsScreen.address,
@@ -129,7 +145,7 @@ fun NavHostControllerInstance(
             )
         }
 
-        composable<ComposeNewMessageScreenNav>{ backStackEntry ->
+        composable<ComposeNewMessageScreenNav> { backStackEntry ->
             val composeDetailsScreen: ComposeNewMessageScreenNav = backStackEntry.toRoute()
             ComposeNewMessage(
                 navController = navController,
@@ -138,15 +154,15 @@ fun NavHostControllerInstance(
             )
         }
 
-        composable<SettingsScreenNav>{
+        composable<SettingsScreenNav> {
             SettingsMain(navController = navController)
         }
 
-        composable<DeveloperModeScreen>{
+        composable<DeveloperModeScreen> {
             DeveloperModeMain(navController)
         }
 
-        composable<ImageViewScreenNav>{ backStackEntry ->
+        composable<ImageViewScreenNav> { backStackEntry ->
             val imageViewScreen: ImageViewScreenNav = backStackEntry.toRoute()
             MediaMain(
                 contentUri = imageViewScreen.contentUri.toUri(),
@@ -167,7 +183,7 @@ private fun FoldOpen(
     navController: NavHostController,
 ) {
     Row {
-        Column(modifier = Modifier.fillMaxWidth(0.5f)){
+        Column(modifier = Modifier.fillMaxWidth(0.5f)) {
             ThreadConversationLayout(
                 threadsViewModel = threadsViewModel,
                 navController = navController,
@@ -175,7 +191,7 @@ private fun FoldOpen(
             )
         }
 
-        if(!homeScreenNav.address.isNullOrEmpty()) {
+        if (!homeScreenNav.address.isNullOrEmpty()) {
             Column {
                 ConversationsMainLayout(
                     address = homeScreenNav.address,
@@ -185,8 +201,7 @@ private fun FoldOpen(
                     foldOpen = true
                 )
             }
-        }
-        else {
+        } else {
             Column(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.Center,
@@ -203,7 +218,8 @@ private fun FoldOpen(
 fun NoMessageSelected() {
     Text(
         stringResource(
-            R.string.select_a_conversation_from_the_list_on_the_left),
+            R.string.select_a_conversation_from_the_list_on_the_left
+        ),
         fontSize = 12.sp,
         textAlign = TextAlign.Center
     )


### PR DESCRIPTION
Sometimes, the database is unreadable, either due to lost encryption keys, or otherwise.
This feature provides a safety net, such that instead of crashing the application, the user is given the ability to erase data and restart.
This pull request addresses the issue reported in Issue #59 