### PR TITLE
Fixed notification bug.

### DIFF
--- a/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Notifications.kt
+++ b/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/extensions/context/Notifications.kt
@@ -19,6 +19,7 @@ import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.net.toUri
 import com.afkanerd.lib_smsmms_android.R
+import com.afkanerd.smswithoutborders_libsmsmms.activities.NotificationsInitializer
 import com.afkanerd.smswithoutborders_libsmsmms.data.entities.Conversations
 import com.afkanerd.smswithoutborders_libsmsmms.receivers.SmsMmsActionsImpl
 import com.afkanerd.smswithoutborders_libsmsmms.receivers.SmsTextReceivedReceiver.Companion.SMS_SENT_BROADCAST_INTENT_LIB
@@ -115,6 +116,17 @@ fun Context.notify(
 
             return@with
         }
+
+
+        val context = this@notify
+
+        // Before issuing the notification, let's create the notification channel.
+        NotificationsInitializer.create(context) // Create channel if not exist
+        // Android 8 (Oreo) and above requires that notifications have known notification channels.
+        // This is offers the user lots of control, for example, with setting different tones for different contacts.
+        // For now, we only group all notifications into the exact same category (a.k.a channel).
+        builder.setChannelId(context.getString(R.string.incoming_messages_channel_id))
+
         // notificationId is a unique int for each notification that you must define.
         notify(conversation.sms?.thread_id ?: 0, builder.build())
     }


### PR DESCRIPTION
This fix addresses issue #58.

## The Problem
Notifications stopped showing for certain devices, after regular usage of the app.

## Cause of Problem
The app was issuing notifications without setting a notification channel ID.
This problem only affects users of modern Android smartphones, given that it was [introduced in Android 8 (Oreo)](https://developer.android.com/develop/ui/compose/notifications/channels#:~:text=Starting%20in%20Android%208.0%20(API%20level%2026)%2C%20all%20notifications%20must%20be%20assigned%20to%20a%20channel.)
Also, it wouldn't affect a modern Android user, if the app had set its targetSdkVersion to any value below 27 (Android Oreo). 

## The Solution
The app already had a [default notification channel](https://github.com/smswithoutborders/lib_smsmms_android/blob/371e2aceeaeb9912f18db707c6dda94a6c03c420/lib_smsmms_android/src/main/java/com/afkanerd/smswithoutborders_libsmsmms/activities/NotificationsInitializer.kt#L12) configured and created, which was however, not being used.  In this fix, each time a  message comes in, a call is made to ensure that the notification channel is created if not existing, then the notification is sent via the channel.